### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/singhmayank1250938/ad3806bd-3263-4a48-bcab-5f40614a8670/f290d792-365e-4ac4-bde4-542e00505662/_apis/work/boardbadge/436e9fe5-1d88-4b3a-af51-d08400ad76b1)](https://dev.azure.com/singhmayank1250938/ad3806bd-3263-4a48-bcab-5f40614a8670/_boards/board/t/f290d792-365e-4ac4-bde4-542e00505662/Microsoft.RequirementCategory)
 # My-Second-Repo
 2nd Repo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/singhmayank1250938/ad3806bd-3263-4a48-bcab-5f40614a8670/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.